### PR TITLE
Improving sandboxing

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -19,7 +19,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         _ => Level::TRACE,
     };
 
-    println!("starting");
     // setup logging
     // Set up the default subscriber
     tracing_subscriber::fmt()

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -19,6 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         _ => Level::TRACE,
     };
 
+    println!("starting");
     // setup logging
     // Set up the default subscriber
     tracing_subscriber::fmt()
@@ -104,7 +105,6 @@ mod daemon {
         fs::{self, File},
         io::{self, BufRead, BufReader, Cursor, Read, Write},
         os::unix::{fs::PermissionsExt, net::UnixListener},
-
         path::PathBuf,
         process,
         sync::Arc,
@@ -246,8 +246,7 @@ mod daemon {
                     version: self.version.clone(),
                 })),
                 Command::Run { path, args } => {
-                    let sandbox =
-                        Sandbox::new(&self.config_path).map_err(Error::SandboxError)?;
+                    let sandbox = Sandbox::new(&self.config_path).map_err(Error::SandboxError)?;
                     let run_result = match sandbox.run(path, args.clone()) {
                         Ok((stdout, stderr)) => RunResult {
                             status: 0,
@@ -490,7 +489,6 @@ mod sandbox {
             fd::FromRawFd,
             unix::net::{UnixListener, UnixStream},
         },
-
         path::PathBuf,
         sync::mpsc::{self, Receiver},
         thread::{self, JoinHandle},


### PR DESCRIPTION
# Overview
Sandboxing allows users to execute in an isolated process a program.  It is created in different namespaces with the following flags:
```rust
let clone_flags = CloneFlags::CLONE_NEWUSER
                | CloneFlags::CLONE_NEWNET
                | CloneFlags::CLONE_NEWPID
                | CloneFlags::CLONE_NEWUTS
                | CloneFlags::CLONE_NEWNS;
```
using the `clone` system call.

When created, the Sandbox  the basic folder structure and bootstrap a basic environment with busybox. It waits for commands through unix socket

At the moment everything is very synchronous. The server uses `Receiver<Vec<u8>>` to stream back the stderr and stdout.

## Roadmap
[] Support asynchronous execution (eg keeping a map of jobs and using pipes to dedicated communication)
[] Support different profiles (eg Minimal, WebServer, HomeUser)
[] Add strace option to monitor execution
[] Attach an eBPF program for monitoring
